### PR TITLE
Feature/library index view

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,10 +1,12 @@
 import React from 'react';
 import './App.css';
+import { LibraryIndexView } from './react-components/libraryIndexView';
 
 function App() {
   return (
     <div className="App">
-      
+      <h1>Book Haven</h1>
+      <LibraryIndexView />
     </div>
   );
 }

--- a/src/react-components/libraryIndexView.tsx
+++ b/src/react-components/libraryIndexView.tsx
@@ -10,13 +10,20 @@ export const LibraryIndexView = () => {
     dispatch(fetchLibraries())
   }, [])
 
-  console.log(libraryIndex.libraries)
   return (
     <div>
       <h2>List of Libraries</h2>
       {libraryIndex.loading && <div>Loading...</div>}
       {!libraryIndex.loading && libraryIndex.error ? <div>Error: {libraryIndex.error}</div> : null}
-      {!libraryIndex.loading && libraryIndex.libraries.length ? <p>Libraries have loaded - check the console.</p> : null} 
+      {!libraryIndex.loading && libraryIndex.libraries.length ? (
+        <ul>
+          {
+            libraryIndex.libraries.map(library => (
+              <li key={library.id}>{library.attributes.name}</li>
+            ))
+          }
+        </ul>
+      ) : null} 
     </div>
   )
 }

--- a/src/react-components/libraryIndexView.tsx
+++ b/src/react-components/libraryIndexView.tsx
@@ -1,0 +1,22 @@
+import { useEffect } from 'react';
+import { useAppSelector, useAppDispatch } from '../redux/store';
+import { fetchLibraries } from '../redux/libraryIndex';
+
+export const LibraryIndexView = () => {
+  const libraryIndex = useAppSelector(state => state.libraryIndex);
+  const dispatch = useAppDispatch();
+
+  useEffect(() => {
+    dispatch(fetchLibraries())
+  }, [])
+
+  console.log(libraryIndex.libraries)
+  return (
+    <div>
+      <h2>List of Libraries</h2>
+      {libraryIndex.loading && <div>Loading...</div>}
+      {!libraryIndex.loading && libraryIndex.error ? <div>Error: {libraryIndex.error}</div> : null}
+      {!libraryIndex.loading && libraryIndex.libraries.length ? <p>Libraries have loaded - check the console.</p> : null} 
+    </div>
+  )
+}

--- a/src/redux/libraryIndex.ts
+++ b/src/redux/libraryIndex.ts
@@ -9,8 +9,12 @@ export const fetchLibraries = createAsyncThunk("libraryIndex/fetchLibraries", ()
 
 interface InitialState {
     loading: boolean,
-    libraries: Library[], 
+    libraries: Library[],
     error: string
+}
+
+interface LibraryIndexResponse {
+    data: Library[]
 }
 
 interface Library {
@@ -45,10 +49,10 @@ export const libraryIndexSlice = createSlice({
         builder.addCase(fetchLibraries.pending, (state) => {
             state.loading = true;
         })
-        builder.addCase(fetchLibraries.fulfilled, (state, action: PayloadAction<Library[]>) => {
-                state.loading = false;
-                state.libraries = action.payload;
-                state.error= "";
+        builder.addCase(fetchLibraries.fulfilled, (state, action: PayloadAction<LibraryIndexResponse>) => {
+            state.loading = false;
+            state.libraries = action.payload.data;
+            state.error= "";
         })
         builder.addCase(fetchLibraries.rejected, (state, action) => {
             state.loading = false;

--- a/src/redux/store.ts
+++ b/src/redux/store.ts
@@ -1,4 +1,5 @@
 import { configureStore } from "@reduxjs/toolkit";
+import { TypedUseSelectorHook, useDispatch, useSelector } from "react-redux";
 import libraryIndexReducer from "./libraryIndex";
 import libraryDetailsReducer, { addBook, removeBook } from "./libraryDetails";
 
@@ -12,3 +13,6 @@ const store = configureStore({
 export default store;
 export type RootState = ReturnType<typeof store.getState>;
 export type AppDispatch = typeof store.dispatch;
+
+export const useAppSelector: TypedUseSelectorHook<RootState> = useSelector;
+export const useAppDispatch = () => useDispatch<AppDispatch>();


### PR DESCRIPTION
### Types of changes made?

- [ ]  documentation
- [ ]  testing
- [x]  functionality
- [ ]  styling
- [x]  refactor
- [ ]  bug fix

### What does this PR do?

Adds functionality to render the fulfilled network request data onto the landing page, in order to check and troubleshoot Redux store and actions setup so far. Including:
- Creates a `react-components` directory, and our first component file `libraryIndexView`.
- Writes 2 custom hooks to utilize Redux's `useSelector()` and `useDispatch()` methods with TypeScript.
- Adds `LibraryIndexView` component for basic rending of the libraryIndex state, with conditionals to change display based on the current request lifecycle position.
- Refactors fulfilled case callback function to fix response type-checking and assign the correct value to `state.libraries`

### Relevant Tickets?

- In progress ticket: https://github.com/BookHaven/BookHaven-FE/issues/6 

### Issues / Further review needed?


### Questions / Comments / Relevant Screenshots?

Current landing page view. The Redux store is accurately reflected in Redux DevTools.
![Screenshot 2023-07-11 at 9 38 09 PM](https://github.com/BookHaven/BookHaven-FE/assets/121128718/89dac8f0-7787-4a3c-8a36-9fe63926870b)

