### PR TITLE
Styles/Import and apply two global fonts

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -12,7 +12,7 @@
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Open+Sans:wght@300;400;500;600;700;800&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Grandstander&&family=Raleway&display=swap" rel="stylesheet">
     <!--
       manifest.json provides metadata used when your web app is installed on a
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/

--- a/src/App.css
+++ b/src/App.css
@@ -1,3 +1,12 @@
 * {
-  font-family: 'Open Sans', sans-serif;
+  font-family: 'Raleway', sans-serif;
+  font-weight: 300;
+}
+
+h1,
+h2,
+h3,
+h4 {
+  font-family: 'Grandstander', cursive;
+  font-weight: 600;
 }


### PR DESCRIPTION
### Types of changes made?

- [ ]  documentation
- [ ]  testing
- [ ]  functionality
- [x]  styling
- [ ]  refactor
- [ ]  bug fix

### What does this PR do?

- Updates CSS for two global fonts by importing and applying Grandstander weight 600, and Raleway weight 300.

### Relevant Tickets?

- Finishes iteration or ticket for: 

### Issues / Further review needed?


### Questions / Comments / Relevant Screenshots?
Sample page with fonts applied:
![Screenshot 2023-07-15 at 10 24 22 AM](https://github.com/BookHaven/BookHaven-FE/assets/121128718/be2bb91b-e5e8-475d-b4ca-c86e85b97789)

