### PR TITLE
feat: Add media query for free library image

### DIFF
--- a/src/styles/landingView.css
+++ b/src/styles/landingView.css
@@ -1,3 +1,32 @@
+@media (max-width: 767px) {
+  .library-image {
+    z-index: -2;
+  }
+
+  .landing-text {
+    width: 100%;
+  }
+}
+
+@media (min-width: 768px) {
+  .library-image {
+    height: 90%;
+    min-height: 500px;
+    width: 55%;
+    min-width: 300px;
+    bottom: 0px;
+    position: fixed;
+    right: 0;
+    margin-right: 40px;
+    z-index: 2;
+  }
+
+  .landing-text {
+    width: 35%;
+  }
+}
+
+
 body {
   background: #E4FCFF;
   background-size: cover;
@@ -26,7 +55,6 @@ body {
 .landing-text {
   display: flex;
   flex-direction: column;
-  width: 35%;
   justify-content: center;
 }
 
@@ -39,17 +67,5 @@ body {
 .landing-button:hover {
   background-color: rgb(254, 225, 171);
   cursor: pointer;
-}
-
-.library-image {
-  height: 90%;
-  min-height: 500px;
-  width: 55%;
-  min-width: 300px;
-  bottom: 0px;
-  position: fixed;
-  right: 0;
-  margin-right: 40px;
-  z-index: 2;
 }
 


### PR DESCRIPTION
### Types of changes made?

- [ ]  documentation
- [ ]  testing
- [ ]  functionality
- [x]  styling
- [ ]  refactor
- [ ]  bug fix

### What does this PR do?
- Updates CSS for landing page - added media query for mobile responsiveness. I hid the free library image on mobile screens and expanded the landing text to 100% to fit the screen. 

### Relevant Tickets?
- Finishes iteration or ticket for: Mobile responsiveness for landing page 

### Issues / Further review needed?

### Questions / Comments / Relevant Screenshots?
<img width="442" alt="Screenshot 2023-07-16 at 10 56 19 AM" src="https://github.com/BookHaven/BookHaven-FE/assets/117330760/6f915541-8afe-4482-8d6d-6497e7583d65">